### PR TITLE
Support maps in JSON parsing and serialization.

### DIFF
--- a/tests/json/test_json.cc
+++ b/tests/json/test_json.cc
@@ -85,6 +85,33 @@ static TestCase kTestRoundtripMessages[] = {
     TEST("{\"optional_string\":\"\\uFFFF\"}"),
     EXPECT("{\"optional_string\":\"\xEF\xBF\xBF\"}")
   },
+  // map-field tests
+  {
+    TEST("{\"map_string_string\":{\"a\":\"value1\",\"b\":\"value2\","
+         "\"c\":\"value3\"}}"),
+    EXPECT_SAME
+  },
+  {
+    TEST("{\"map_int32_string\":{\"1\":\"value1\",\"-1\":\"value2\","
+         "\"1234\":\"value3\"}}"),
+    EXPECT_SAME
+  },
+  {
+    TEST("{\"map_bool_string\":{\"false\":\"value1\",\"true\":\"value2\"}}"),
+    EXPECT_SAME
+  },
+  {
+    TEST("{\"map_string_int32\":{\"asdf\":1234,\"jkl;\":-1}}"),
+    EXPECT_SAME
+  },
+  {
+    TEST("{\"map_string_bool\":{\"asdf\":true,\"jkl;\":false}}"),
+    EXPECT_SAME
+  },
+  {
+    TEST("{\"map_string_msg\":{\"asdf\":{\"foo\":42},\"jkl;\":{\"foo\":84}}}"),
+    EXPECT_SAME
+  },
   TEST_SENTINEL
 };
 
@@ -114,6 +141,53 @@ static const upb::MessageDef* BuildTestMessage(
   upb::reffed_ptr<upb::MessageDef> submsg(upb::MessageDef::New());
   submsg->set_full_name("SubMessage", &st);
   AddField(submsg.get(), 1, "foo", UPB_TYPE_INT32, false);
+
+  // Create MapEntryStringString.
+  upb::reffed_ptr<upb::MessageDef> mapentry_string_string(
+      upb::MessageDef::New());
+  mapentry_string_string->set_full_name("MapEntry_String_String", &st);
+  mapentry_string_string->setmapentry(true);
+  AddField(mapentry_string_string.get(), 1, "key", UPB_TYPE_STRING, false);
+  AddField(mapentry_string_string.get(), 2, "value", UPB_TYPE_STRING, false);
+
+  // Create MapEntryInt32String.
+  upb::reffed_ptr<upb::MessageDef> mapentry_int32_string(
+      upb::MessageDef::New());
+  mapentry_int32_string->set_full_name("MapEntry_Int32_String", &st);
+  mapentry_int32_string->setmapentry(true);
+  AddField(mapentry_int32_string.get(), 1, "key", UPB_TYPE_INT32, false);
+  AddField(mapentry_int32_string.get(), 2, "value", UPB_TYPE_STRING, false);
+
+  // Create MapEntryBoolString.
+  upb::reffed_ptr<upb::MessageDef> mapentry_bool_string(
+      upb::MessageDef::New());
+  mapentry_bool_string->set_full_name("MapEntry_Bool_String", &st);
+  mapentry_bool_string->setmapentry(true);
+  AddField(mapentry_bool_string.get(), 1, "key", UPB_TYPE_BOOL, false);
+  AddField(mapentry_bool_string.get(), 2, "value", UPB_TYPE_STRING, false);
+
+  // Create MapEntryStringInt32.
+  upb::reffed_ptr<upb::MessageDef> mapentry_string_int32(
+      upb::MessageDef::New());
+  mapentry_string_int32->set_full_name("MapEntry_String_Int32", &st);
+  mapentry_string_int32->setmapentry(true);
+  AddField(mapentry_string_int32.get(), 1, "key", UPB_TYPE_STRING, false);
+  AddField(mapentry_string_int32.get(), 2, "value", UPB_TYPE_INT32, false);
+
+  // Create MapEntryStringBool.
+  upb::reffed_ptr<upb::MessageDef> mapentry_string_bool(upb::MessageDef::New());
+  mapentry_string_bool->set_full_name("MapEntry_String_Bool", &st);
+  mapentry_string_bool->setmapentry(true);
+  AddField(mapentry_string_bool.get(), 1, "key", UPB_TYPE_STRING, false);
+  AddField(mapentry_string_bool.get(), 2, "value", UPB_TYPE_BOOL, false);
+
+  // Create MapEntryStringMessage.
+  upb::reffed_ptr<upb::MessageDef> mapentry_string_msg(upb::MessageDef::New());
+  mapentry_string_msg->set_full_name("MapEntry_String_Message", &st);
+  mapentry_string_msg->setmapentry(true);
+  AddField(mapentry_string_msg.get(), 1, "key", UPB_TYPE_STRING, false);
+  AddField(mapentry_string_msg.get(), 2, "value", UPB_TYPE_MESSAGE, false,
+           upb::upcast(submsg.get()));
 
   // Create MyEnum.
   upb::reffed_ptr<upb::EnumDef> myenum(upb::EnumDef::New());
@@ -150,13 +224,33 @@ static const upb::MessageDef* BuildTestMessage(
   AddField(md.get(), 19, "optional_enum",   UPB_TYPE_ENUM, true,
            upb::upcast(myenum.get()));
 
+  AddField(md.get(), 20, "map_string_string", UPB_TYPE_MESSAGE, true,
+           upb::upcast(mapentry_string_string.get()));
+  AddField(md.get(), 21, "map_int32_string", UPB_TYPE_MESSAGE, true,
+           upb::upcast(mapentry_int32_string.get()));
+  AddField(md.get(), 22, "map_bool_string", UPB_TYPE_MESSAGE, true,
+           upb::upcast(mapentry_bool_string.get()));
+  AddField(md.get(), 23, "map_string_int32", UPB_TYPE_MESSAGE, true,
+           upb::upcast(mapentry_string_int32.get()));
+  AddField(md.get(), 24, "map_string_bool", UPB_TYPE_MESSAGE, true,
+           upb::upcast(mapentry_string_bool.get()));
+  AddField(md.get(), 25, "map_string_msg", UPB_TYPE_MESSAGE, true,
+           upb::upcast(mapentry_string_msg.get()));
+
   // Add both to our symtab.
-  upb::Def* defs[3] = {
+  upb::Def* defs[9] = {
     upb::upcast(submsg.ReleaseTo(&defs)),
     upb::upcast(myenum.ReleaseTo(&defs)),
     upb::upcast(md.ReleaseTo(&defs)),
+    upb::upcast(mapentry_string_string.ReleaseTo(&defs)),
+    upb::upcast(mapentry_int32_string.ReleaseTo(&defs)),
+    upb::upcast(mapentry_bool_string.ReleaseTo(&defs)),
+    upb::upcast(mapentry_string_int32.ReleaseTo(&defs)),
+    upb::upcast(mapentry_string_bool.ReleaseTo(&defs)),
+    upb::upcast(mapentry_string_msg.ReleaseTo(&defs)),
   };
-  symtab->Add(defs, 3, &defs, &st);
+  symtab->Add(defs, 9, &defs, &st);
+  ASSERT(st.ok());
 
   // Return TestMessage.
   return symtab->LookupMessage("TestMessage");

--- a/upb/def.h
+++ b/upb/def.h
@@ -368,6 +368,7 @@ UPB_DEFINE_DEF(upb::FieldDef, fielddef, FIELD,
   bool IsString() const;
   bool IsSequence() const;
   bool IsPrimitive() const;
+  bool IsMap() const;
 
   // How integers are encoded.  Only meaningful for integer types.
   // Defaults to UPB_INTFMT_VARIABLE, and is reset when "type" changes.
@@ -592,6 +593,7 @@ bool upb_fielddef_issubmsg(const upb_fielddef *f);
 bool upb_fielddef_isstring(const upb_fielddef *f);
 bool upb_fielddef_isseq(const upb_fielddef *f);
 bool upb_fielddef_isprimitive(const upb_fielddef *f);
+bool upb_fielddef_ismap(const upb_fielddef *f);
 int64_t upb_fielddef_defaultint64(const upb_fielddef *f);
 int32_t upb_fielddef_defaultint32(const upb_fielddef *f);
 uint64_t upb_fielddef_defaultuint64(const upb_fielddef *f);
@@ -979,6 +981,10 @@ UPB_INLINE upb_oneofdef *upb_msgdef_ntoo_mutable(upb_msgdef *m,
 
 void upb_msgdef_setmapentry(upb_msgdef *m, bool map_entry);
 bool upb_msgdef_mapentry(const upb_msgdef *m);
+
+// Well-known field tag numbers for map-entry messages.
+#define UPB_MAPENTRY_KEY   1
+#define UPB_MAPENTRY_VALUE 2
 
 const upb_oneofdef *upb_msgdef_findoneof(const upb_msgdef *m,
                                           const char *name);
@@ -1479,6 +1485,7 @@ inline bool FieldDef::IsSubMessage() const {
 }
 inline bool FieldDef::IsString() const { return upb_fielddef_isstring(this); }
 inline bool FieldDef::IsSequence() const { return upb_fielddef_isseq(this); }
+inline bool FieldDef::IsMap() const { return upb_fielddef_ismap(this); }
 inline int64_t FieldDef::default_int64() const {
   return upb_fielddef_defaultint64(this);
 }

--- a/upb/json/parser.h
+++ b/upb/json/parser.h
@@ -23,12 +23,30 @@ class Parser;
 
 UPB_DECLARE_TYPE(upb::json::Parser, upb_json_parser);
 
-// Internal-only struct used by the parser.
+// Internal-only struct used by the parser. A parser frame corresponds
+// one-to-one with a handler (sink) frame.
 typedef struct {
  UPB_PRIVATE_FOR_CPP
   upb_sink sink;
+  // The current message in which we're parsing, and the field whose value we're
+  // expecting next.
   const upb_msgdef *m;
   const upb_fielddef *f;
+
+  // We are in a repeated-field context, ready to emit mapentries as
+  // submessages. This flag alters the start-of-object (open-brace) behavior to
+  // begin a sequence of mapentry messages rather than a single submessage.
+  bool is_map;
+  // We are in a map-entry message context. This flag is set when parsing the
+  // value field of a single map entry and indicates to all value-field parsers
+  // (subobjects, strings, numbers, and bools) that the map-entry submessage
+  // should end as soon as the value is parsed.
+  bool is_mapentry;
+  // If |is_map| or |is_mapentry| is true, |mapfield| refers to the parent
+  // message's map field that we're currently parsing. This differs from |f|
+  // because |f| is the field in the *current* message (i.e., the map-entry
+  // message itself), not the parent's field that leads to this map.
+  const upb_fielddef *mapfield;
 } upb_jsonparser_frame;
 
 

--- a/upb/table.c
+++ b/upb/table.c
@@ -40,12 +40,16 @@ char *upb_strdup(const char *s) {
 }
 
 char *upb_strdup2(const char *s, size_t len) {
+  // Prevent overflow errors.
+  if (len == SIZE_MAX) return NULL;
   // Always null-terminate, even if binary data; but don't rely on the input to
   // have a null-terminating byte since it may be a raw binary buffer.
   size_t n = len + 1;
   char *p = malloc(n);
-  if (p) memcpy(p, s, len);
-  p[len] = 0;
+  if (p) {
+    memcpy(p, s, len);
+    p[len] = 0;
+  }
   return p;
 }
 


### PR DESCRIPTION
This is a sync of our internal development of JSON parsing and
serialization. It implements native understanding of MapEntry
submessages, so that map fields with (key, value) pairs are serialized
as JSON maps (objects) natively rather than as arrays of objects with
'key' and 'value' fields. The parser also now understands how to emit
handler calls corresponding to MapEntry objects when processing a map
field.

This sync also picks up a bugfix in `table.c` to handle an alloc-failed
case.